### PR TITLE
Byte stream

### DIFF
--- a/master
+++ b/master
@@ -1,2 +1,0 @@
-* [32mMemoryBuffer[m
-  master[m

--- a/pkg/io/bytestream.go
+++ b/pkg/io/bytestream.go
@@ -1,6 +1,9 @@
 package io
 
-import "sync"
+import (
+	"log"
+	"sync"
+)
 
 // DefaultMaxBufferSize is the default maximum number of bytes that a ByteStream
 // will read from the underlying buffer at at once.
@@ -31,4 +34,69 @@ func NewByteStreamDetailed(buffer OutputBuffer, maxReadSize int) *ByteStream {
 		buffer:      buffer,
 		maxReadSize: maxReadSize,
 	}
+}
+
+// Stream returns a chanel that streams the content of the underlying OutputBuffer.
+func (b *ByteStream) Stream() <-chan []byte {
+
+	bailEarly := true
+
+	func() {
+		b.mutex.Lock()
+		defer b.mutex.Unlock()
+
+		if !b.goroutineStarted {
+			bailEarly = false
+			b.goroutineStarted = true
+		}
+	}()
+
+	// If some other call to Stream has already created the goroutine, then
+	// there's nothing for this call to do other than to return the channel.
+	if bailEarly {
+		return b.channel
+	}
+
+	go func() {
+		var nextByte int64
+		readBuffer := make([]byte, b.maxReadSize)
+
+		for {
+			bufferSize, _ := b.buffer.waitForChange(nextByte)
+
+			// At this point the underlying buffer could be closed, there could
+			// be new bytes in the buffer to process, or both.
+
+			if bufferSize == nextByte {
+				// No new bytes to process; the buffer must be closed and this
+				// streamer must have consumed all the bytes that were written
+				// to the buffer. Terminate the goroutine.
+				close(b.channel)
+				return
+			}
+
+			if n, err := b.buffer.ReadAt(readBuffer, nextByte); err != nil {
+				// If ReadAt fails, we'l assume the buffer is in a bad state
+				// and that future reads would also fail.
+
+				log.Printf("Unexpected failure reading from underlying buffer: %v", err)
+
+				close(b.channel)
+				return
+			} else if n > 0 {
+				// Craete a copy here because we're reusing readBuffer here.
+				bufToWrite := make([]byte, n)
+				copy(bufToWrite, readBuffer[0:n])
+
+				b.channel <- bufToWrite
+				nextByte += int64(n)
+			}
+
+			// If n == 0, then it's possible that new bytes were written to the
+			// buffer since we inspected its size above.  In that case, we'll
+			// get the updated size and reevaluate on the next iteration.
+		}
+	}()
+
+	return b.channel
 }

--- a/pkg/io/bytestream.go
+++ b/pkg/io/bytestream.go
@@ -1,0 +1,34 @@
+package io
+
+import "sync"
+
+// DefaultMaxBufferSize is the default maximum number of bytes that a ByteStream
+// will read from the underlying buffer at at once.
+const DefaultMaxBufferSize = 1024
+
+// ByteStream enables clients to stream bytes from an OutputBuffer.
+type ByteStream struct {
+	buffer      OutputBuffer
+	channel     chan []byte
+	maxReadSize int
+
+	// mutex guards the fields that follow
+	mutex            sync.Mutex
+	goroutineStarted bool
+}
+
+// NewByteStream creates and returns a new ByteStream associated with the
+// given buffer with a read buffer size of DefaultMaxBufferSize.
+func NewByteStream(buffer OutputBuffer) *ByteStream {
+	return NewByteStreamDetailed(buffer, DefaultMaxBufferSize)
+}
+
+// NewByteStream creates and returns a new ByteStream associated with the
+// given buffer with a read buffer size of the given maxReadSize.
+func NewByteStreamDetailed(buffer OutputBuffer, maxReadSize int) *ByteStream {
+	return &ByteStream{
+		channel:     make(chan []byte),
+		buffer:      buffer,
+		maxReadSize: maxReadSize,
+	}
+}

--- a/pkg/io/bytestream_test.go
+++ b/pkg/io/bytestream_test.go
@@ -1,0 +1,96 @@
+package io_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/obaraelijah/secureproc/pkg/io"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ByteStream(t *testing.T) {
+	const iterationCount = 5
+	payload := []byte("hello")
+	output := make([]byte, 0, iterationCount*len(payload))
+
+	buffer := io.NewMemoryBuffer()
+	stream := io.NewByteStream(buffer)
+
+	byteCount := 0
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		for content := range stream.Stream() {
+			byteCount += len(content)
+			output = append(output, content...)
+		}
+		wg.Done()
+	}()
+
+	for i := 0; i < iterationCount; i++ {
+		buffer.Write(payload)
+	}
+
+	buffer.Close()
+	wg.Wait()
+
+	assert.Equal(t, iterationCount*len(payload), byteCount)
+	assert.Equal(t, []byte("hellohellohellohellohello"), output)
+}
+
+func Test_ByteStream_MultipleCallsToStream(t *testing.T) {
+	buffer := io.NewMemoryBuffer()
+	stream := io.NewByteStream(buffer)
+
+	buffer.Write([]byte("hello"))
+	assert.Equal(t, []byte("hello"), <-stream.Stream())
+
+	buffer.Write([]byte("world"))
+	assert.Equal(t, []byte("world"), <-stream.Stream())
+
+	buffer.Close()
+	assert.Nil(t, <-stream.Stream())
+}
+
+func Test_ByteStream_MultipleReaders(t *testing.T) {
+	buffer := io.NewMemoryBuffer()
+	stream1 := io.NewByteStream(buffer).Stream()
+	stream2 := io.NewByteStream(buffer).Stream()
+
+	buffer.Write([]byte("hello"))
+	assert.Equal(t, []byte("hello"), <-stream1)
+	assert.Equal(t, []byte("hello"), <-stream2)
+
+	buffer.Write([]byte("world"))
+	assert.Equal(t, []byte("world"), <-stream1)
+	assert.Equal(t, []byte("world"), <-stream2)
+
+	buffer.Close()
+	assert.Nil(t, <-stream1)
+	assert.Nil(t, <-stream2)
+}
+
+/*
+
+func Test_ByteStream_Stream(t *testing.T) {
+	buffer := io.NewMemoryBuffer()
+	stream := io.NewByteStream(buffer)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < 100; j++ {
+				stream.Stream()
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+*/

--- a/pkg/io/memorybuffer.go
+++ b/pkg/io/memorybuffer.go
@@ -12,9 +12,10 @@ const DefaultInitialMemoryBufferCapacity = 4096
 // it has been read to enable multiple clients to read what is written to this
 // buffer.
 type MemoryBuffer struct {
-	mutex   sync.RWMutex
-	content []byte
-	closed  bool
+	mutex    sync.RWMutex
+	waitCond *sync.Cond // For signaling changes
+	content  []byte
+	closed   bool
 }
 
 // NewMemoryBuffer creates and returns a MemoryBuffer with an initial capacity
@@ -26,9 +27,13 @@ func NewMemoryBuffer() *MemoryBuffer {
 // NewMemoryBufferDetailed creates and returns a MemoryBuffer with the given
 // initialCapacity.
 func NewMemoryBufferDetailed(initialCapacity int) *MemoryBuffer {
-	return &MemoryBuffer{
+	b := &MemoryBuffer{
 		content: make([]byte, 0, initialCapacity),
 	}
+
+	b.waitCond = sync.NewCond(&b.mutex)
+
+	return b
 }
 
 // Write appends newContent to this MemoryBuffer.  The returned bytesWritten is
@@ -42,6 +47,7 @@ func (b *MemoryBuffer) Write(newContent []byte) (bytesWritten int, err error) {
 	}
 
 	b.content = append(b.content, newContent...)
+	b.waitCond.Broadcast() // Signal all waiting goroutines
 
 	return len(newContent), nil
 }
@@ -68,6 +74,7 @@ func (b *MemoryBuffer) Close() error {
 	defer b.mutex.Unlock()
 
 	b.closed = true
+	b.waitCond.Broadcast() // Signal all waiting goroutines
 
 	return nil
 }
@@ -86,4 +93,19 @@ func (b *MemoryBuffer) Closed() bool {
 	defer b.mutex.Unlock()
 
 	return b.closed
+}
+
+// waitForChange blocks waiting for a change to this memory buffer.  The given
+// size is the last known buffer size.  This function unblocks if:
+// * The size is less than the current size of the buffer
+// * The buffer is closed.
+func (b *MemoryBuffer) waitForChange(size int64) (newBufferSize int64, closed bool) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	for !b.closed && size == int64(len(b.content)) {
+		b.waitCond.Wait()
+	}
+
+	return int64(len(b.content)), b.closed
 }

--- a/pkg/io/outputbuffer.go
+++ b/pkg/io/outputbuffer.go
@@ -1,0 +1,15 @@
+package io
+
+import (
+	goio "io"
+)
+
+// OutputBuffer is an abstraction over buffers to which the job manager
+// can write output.
+type OutputBuffer interface {
+	goio.Writer
+	goio.ReaderAt
+	goio.Closer
+
+	waitForChange(nextByte int64) (bufferSize int64, closed bool)
+}


### PR DESCRIPTION
Add ByteStream
This change introduces the ByteStream component and associated unit
tests.  It updates the MemoryBuffer component to enable the ByteStream
component to block waiting for changes.

This also introduces a new interface -- OutputBuffer.  This is used to
decouple the ByteStream from the concrete OutputBuffer.  That way, if at
some time in the future we wanted to support writing to something else
(e.g., a file), we could reuse the ByteStream component without
modification.