### PR TITLE
feat: Add os adaptation layer

### DIFF
--- a/pkg/adaptation/os/adapter.go
+++ b/pkg/adaptation/os/adapter.go
@@ -1,0 +1,49 @@
+package os
+
+import (
+	goos "os"
+)
+
+type FileMode = goos.FileMode
+
+// Adapter serves as a shim between between callers of standard os.* APIs
+// and the functions themselves.  The default behavior is simply to dispatch
+// the call to the corresponding os.* function.
+//
+// If the field associated with that function is non-nil, then the adapter will
+// dispatch to that function instead.
+type Adapter struct {
+	MkdirAllFn  func(path string, perm goos.FileMode) error
+	RemoveFn    func(name string) error
+	WriteFileFn func(name string, data []byte, perm goos.FileMode) error
+}
+
+func (o *Adapter) MkdirAll(path string, perm goos.FileMode) error {
+	fn := goos.MkdirAll
+
+	if o != nil && o.MkdirAllFn != nil {
+		fn = o.MkdirAllFn
+	}
+
+	return fn(path, perm)
+}
+
+func (o *Adapter) Remove(name string) error {
+	fn := goos.Remove
+
+	if o != nil && o.RemoveFn != nil {
+		fn = o.RemoveFn
+	}
+
+	return fn(name)
+}
+
+func (o *Adapter) WriteFile(name string, data []byte, perm goos.FileMode) error {
+	fn := goos.WriteFile
+
+	if o != nil && o.WriteFileFn != nil {
+		fn = o.WriteFileFn
+	}
+
+	return fn(name, data, perm)
+}

--- a/pkg/adaptation/os/ostest/mkdirallrecorder.go
+++ b/pkg/adaptation/os/ostest/mkdirallrecorder.go
@@ -1,0 +1,21 @@
+package ostest
+
+import "github.com/obaraelijah/secureproc/pkg/adaptation/os"
+
+type MkdirAllRecord struct {
+	Path string
+	Perm os.FileMode
+}
+type MkdirAllRecorder struct {
+	Events    []*MkdirAllRecord
+	NextError error
+}
+
+func (w *MkdirAllRecorder) MkdirAll(path string, perm os.FileMode) error {
+	w.Events = append(w.Events, &MkdirAllRecord{
+		Path: path,
+		Perm: perm,
+	})
+
+	return w.NextError
+}

--- a/pkg/adaptation/os/ostest/nilfilewriterecorder.go
+++ b/pkg/adaptation/os/ostest/nilfilewriterecorder.go
@@ -1,0 +1,9 @@
+package ostest
+
+import "github.com/obaraelijah/secureproc/pkg/adaptation/os"
+
+type NilFileWriter struct{}
+
+func (w *NilFileWriter) WriteFile(string, []byte, os.FileMode) error {
+	return nil
+}

--- a/pkg/adaptation/os/ostest/removerecorder.go
+++ b/pkg/adaptation/os/ostest/removerecorder.go
@@ -1,0 +1,17 @@
+package ostest
+
+type RemoveRecord struct {
+	Path string
+}
+type RemoveRecorder struct {
+	Events    []*RemoveRecord
+	NextError error
+}
+
+func (w *RemoveRecorder) Remove(path string) error {
+	w.Events = append(w.Events, &RemoveRecord{
+		Path: path,
+	})
+
+	return w.NextError
+}

--- a/pkg/adaptation/os/ostest/writefilerecorder.go
+++ b/pkg/adaptation/os/ostest/writefilerecorder.go
@@ -1,0 +1,22 @@
+package ostest
+
+import "github.com/obaraelijah/secureproc/pkg/adaptation/os"
+
+type WriteFileRecord struct {
+	Name string
+	Data []byte
+	Perm os.FileMode
+}
+type WriteFileRecorder struct {
+	Events    []*WriteFileRecord
+	NextError error
+}
+
+func (w *WriteFileRecorder) WriteFile(name string, data []byte, perm os.FileMode) error {
+	w.Events = append(w.Events, &WriteFileRecord{
+		Name: name,
+		Data: data,
+		Perm: perm,
+	})
+	return w.NextError
+}


### PR DESCRIPTION
Directly making calls to os.XXX APIs is difficult to unit test.  We
wouldn't, for example, want a unit test to be manipulating the
filesystem.

This change adds a simple adaptation layer over the os APIs.  Clients of
the os.* function will use this adaptation layer.  The adaptation layer,
by default, invokes the corresponding os.* function; however, users can
inject a stub function to call instead.  Unit tests can use that to
ensure that the expected calls are made to the os.* functions, in the
expected order, with the expected parameters.