### PR TITLE
Cgroup management api

### DIFF
--- a/pkg/cgroup/v1/base.go
+++ b/pkg/cgroup/v1/base.go
@@ -1,0 +1,33 @@
+package cgroup
+
+import (
+	"fmt"
+
+	"github.com/obaraelijah/secureproc/pkg/adaptation/os"
+)
+
+const DefaultFileMode os.FileMode = 0644
+
+// base is the base type for all cgroup controllers
+type base struct {
+	osAdapter *os.Adapter
+	// name is the controller name
+	name string
+}
+
+func newBase(name string, osAdapter *os.Adapter) base {
+	return base{
+		osAdapter: osAdapter,
+		name:      name,
+	}
+}
+
+// Name returns the name of this cgroup controller
+func (b *base) Name() string {
+	return b.name
+}
+
+// write update the cgroup file constructed with the given pathFmt and args with the given value.
+func (b *base) write(value []byte, pathFmt string, args ...interface{}) error {
+	return b.osAdapter.WriteFile(fmt.Sprintf(pathFmt, args...), value, DefaultFileMode)
+}

--- a/pkg/cgroup/v1/blockio.go
+++ b/pkg/cgroup/v1/blockio.go
@@ -1,0 +1,53 @@
+package cgroup
+
+import "github.com/obaraelijah/secureproc/pkg/adaptation/os"
+
+const (
+	BlkioThrottleReadBpsDevice  = "blkio.throttle.read_bps_device"
+	BlkioThrottleWriteBpsDevice = "blkio.throttle.write_bps_device"
+)
+
+type blockIo struct {
+	base
+	readBpsDevice  *string
+	writeBpsDevice *string
+}
+
+func NewBlockIoController() *blockIo {
+	return NewBlockIoControllerDetailed(nil)
+}
+
+func NewBlockIoControllerDetailed(osAdapter *os.Adapter) *blockIo {
+	return &blockIo{
+		base: newBase("blkio", osAdapter),
+	}
+}
+
+func (b *blockIo) Apply(path string) error {
+	if b.readBpsDevice != nil {
+		if err := b.write([]byte(*b.readBpsDevice), "%s/%s", path, BlkioThrottleReadBpsDevice); err != nil {
+			return err
+		}
+	}
+
+	if b.writeBpsDevice != nil {
+		if err := b.write([]byte(*b.writeBpsDevice), "%s/%s", path, BlkioThrottleWriteBpsDevice); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Setter methods that enable method chaining
+func (b *blockIo) SetReadBpsDevice(value string) *blockIo {
+	b.readBpsDevice = &value
+
+	return b
+}
+
+func (b *blockIo) SetWriteBpsDevice(value string) *blockIo {
+	b.writeBpsDevice = &value
+
+	return b
+}

--- a/pkg/cgroup/v1/blockio_test.go
+++ b/pkg/cgroup/v1/blockio_test.go
@@ -1,0 +1,35 @@
+package cgroup_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/obaraelijah/secureproc/pkg/adaptation/os"
+	"github.com/obaraelijah/secureproc/pkg/adaptation/os/ostest"
+	"github.com/obaraelijah/secureproc/pkg/cgroup/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_blkio_Apply(t *testing.T) {
+	path := "/sys/fs/cgroup/jobs/889f7cc2-9935-4773-aaa1-b94478abc923"
+	writeRecorder := ostest.WriteFileRecorder{}
+	adapter := &os.Adapter{
+		WriteFileFn: writeRecorder.WriteFile,
+	}
+
+	readBps := "1:2 1G"
+	writeBps := "1:3 900M"
+
+	blkio := cgroup.NewBlockIoControllerDetailed(adapter).
+		SetReadBpsDevice(readBps).
+		SetWriteBpsDevice(writeBps)
+
+	blkio.Apply(path)
+
+	assert.Equal(t, 2, len(writeRecorder.Events))
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.BlkioThrottleReadBpsDevice), writeRecorder.Events[0].Name)
+	assert.Equal(t, []byte(readBps), writeRecorder.Events[0].Data)
+
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.BlkioThrottleWriteBpsDevice), writeRecorder.Events[1].Name)
+	assert.Equal(t, []byte(writeBps), writeRecorder.Events[1].Data)
+}

--- a/pkg/cgroup/v1/cgrouptest/dummyController.go
+++ b/pkg/cgroup/v1/cgrouptest/dummyController.go
@@ -1,0 +1,19 @@
+package cgrouptest
+
+type Controller interface {
+	Name() string
+	Apply(path string) error
+}
+
+type DummyController struct {
+	ControllerName   string
+	ApplyReturnValue error
+}
+
+func (d *DummyController) Name() string {
+	return d.ControllerName
+}
+
+func (d *DummyController) Apply(string) error {
+	return d.ApplyReturnValue
+}

--- a/pkg/cgroup/v1/controller.go
+++ b/pkg/cgroup/v1/controller.go
@@ -1,0 +1,6 @@
+package cgroup
+
+type Controller interface {
+	Name() string
+	Apply(path string) error
+}

--- a/pkg/cgroup/v1/cpu.go
+++ b/pkg/cgroup/v1/cpu.go
@@ -1,0 +1,60 @@
+package cgroup
+
+import (
+	"fmt"
+
+	"github.com/obaraelijah/secureproc/pkg/adaptation/os"
+)
+
+const (
+	CpuPeriodFilename = "cpu.cfs_period_us"
+	CpuQuotaFilename  = "cpu.cfs_quota_us"
+
+	defaultPeriodUs = 100000
+)
+
+var defaultPeriodBytes = []byte(fmt.Sprintf("%d", defaultPeriodUs))
+
+// cpu implements cgroup v2 control using CFS Bandwidth Control.
+// See doc/Documentation/scheduler/sched-bwc.txt in the kernel source tree for
+// additional information.
+//
+// This implementation exposes that functionality in terms of how much of the
+// available CPU resources a collection of processes can use (0.5 = half a CPU,
+// 1.0 = 1 CPU, 1.5 = 1 and a half CPUs, ...).
+// The period is defaultPeriodUs and the quota is cpus*period.
+type cpu struct {
+	base
+	cpus *float64
+}
+
+func NewCpuController() *cpu {
+	return NewCpuControllerDetailed(nil)
+}
+
+func NewCpuControllerDetailed(osAdapter *os.Adapter) *cpu {
+	return &cpu{
+		base: newBase("cpu", osAdapter),
+	}
+}
+
+func (c *cpu) SetCpus(value float64) *cpu {
+	c.cpus = &value
+
+	return c
+}
+
+func (c *cpu) Apply(path string) error {
+	if c.cpus != nil {
+		if err := c.write(defaultPeriodBytes, "%s/%s", path, CpuPeriodFilename); err != nil {
+			return err
+		}
+
+		quota := fmt.Sprintf("%d", int(*c.cpus*defaultPeriodUs))
+		if err := c.write([]byte(quota), "%s/%s", path, CpuQuotaFilename); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cgroup/v1/cpu_test.go
+++ b/pkg/cgroup/v1/cpu_test.go
@@ -1,0 +1,29 @@
+package cgroup_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/obaraelijah/secureproc/pkg/adaptation/os"
+	"github.com/obaraelijah/secureproc/pkg/adaptation/os/ostest"
+	"github.com/obaraelijah/secureproc/pkg/cgroup/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cpu_Apply(t *testing.T) {
+	path := "/sys/fs/cgroup/jobs/889f7cc2-9935-4773-aaa1-b94478abc923"
+	writeRecorder := ostest.WriteFileRecorder{}
+	adapter := &os.Adapter{
+		WriteFileFn: writeRecorder.WriteFile,
+	}
+
+	cpu := cgroup.NewCpuControllerDetailed(adapter).SetCpus(2.0)
+	cpu.Apply(path)
+
+	assert.Equal(t, 2, len(writeRecorder.Events))
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.CpuPeriodFilename), writeRecorder.Events[0].Name)
+	assert.Equal(t, []byte("100000"), writeRecorder.Events[0].Data)
+
+	assert.Equal(t, fmt.Sprintf("%s/%s", path, cgroup.CpuQuotaFilename), writeRecorder.Events[1].Name)
+	assert.Equal(t, []byte("200000"), writeRecorder.Events[1].Data)
+}

--- a/pkg/cgroup/v1/doc.go
+++ b/pkg/cgroup/v1/doc.go
@@ -1,0 +1,9 @@
+// Package cgroup provides an simple abstraction over the cgroup v1 interface.
+// The rationale to implement was driven by the fact that on my system, both
+// the v1 and v2 interfaces are mounted and the v1 interface is in use.
+//
+// I've versioned the package structure so that we could easily build a v2
+// implementation.  We could also add some code to the parent package to
+// enable us to examine the system and automatically pick the most suitable
+// implementation.
+package cgroup

--- a/pkg/cgroup/v1/memory.go
+++ b/pkg/cgroup/v1/memory.go
@@ -1,0 +1,38 @@
+package cgroup
+
+import "github.com/obaraelijah/secureproc/pkg/adaptation/os"
+
+const (
+	MemoryLimitInBytesFilename = "memory.limit_in_bytes"
+)
+
+type memory struct {
+	base
+	limit *string
+}
+
+func NewMemory() *memory {
+	return NewMemoryDetailed(nil)
+}
+
+func NewMemoryDetailed(osAdapter *os.Adapter) *memory {
+	return &memory{
+		base: newBase("memory", osAdapter),
+	}
+}
+
+func (m *memory) SetLimit(value string) *memory {
+	m.limit = &value
+
+	return m
+}
+
+func (m *memory) Apply(path string) error {
+	if m.limit != nil {
+		if err := m.write([]byte(*m.limit), "%s/%s", path, MemoryLimitInBytesFilename); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add cgroup management API

This change introduces the cgroup management API.  In includes the Set
along with the cpu, memory, and blkio controllers.  It also includes a
dummy controller implementation for unit testing.